### PR TITLE
write code to airtable only when in production environment

### DIFF
--- a/app/Console/Commands/ImportAirtable.php
+++ b/app/Console/Commands/ImportAirtable.php
@@ -74,7 +74,7 @@ class ImportAirtable extends Command
 
             $code->save();
             // update code in airtable
-            if (empty($record['fields']['code']) || $record['fields']['code'] != $code->code) {
+            if (\App::environment('production') && (empty($record['fields']['code']) || $record['fields']['code'] != $code->code)) {
                 Airtable::table('default')->patch($record['id'], ['code' => $code->code]);
             }
         });


### PR DESCRIPTION
avoid writing generated code into airtable when in development environment
consider disable writing generated code into airtable in the future and use only https://kod.sng.sk/print instead