### PR TITLE
change generated code dots limit

### DIFF
--- a/app/Models/Code.php
+++ b/app/Models/Code.php
@@ -28,7 +28,7 @@ class Code extends Model
     public static function randomCode()
     {
         $code = str_repeat('0', self::ROWS * self::COLS);
-        $dots_count = rand(2, 3);
+        $dots_count = rand(2, 4);
         for ($i = 0; $i < $dots_count; $i++) {
             $randomPos = rand(0, self::ROWS * self::COLS - 1);
             $code[$randomPos] = '1';


### PR DESCRIPTION
we already reached limit with generated codes for given amount of dots (the result is imported `item` without `code` -> also import freeze in endless loop, since it can't find any unique code anymore)

this is more like "hotfix" - it would be nicer to come up with nicer solution for such a scenario